### PR TITLE
sdt: Prototype implementation of SDT probes using hot-patching

### DIFF
--- a/cddl/contrib/opensolaris/cmd/dtrace/test/tst/common/sdt/tst.sdtargs.d
+++ b/cddl/contrib/opensolaris/cmd/dtrace/test/tst/common/sdt/tst.sdtargs.d
@@ -27,7 +27,7 @@
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 /*
- * ASSERTION: Verify that argN (1..7) variables are properly remapped.
+ * ASSERTION: Verify that argN (1..6) variables are properly remapped.
  */
 
 BEGIN
@@ -44,13 +44,12 @@ ERROR
 }
 
 test:::sdttest
-/arg0 != 1 || arg1 != 2 || arg2 != 3 || arg3 != 4 || arg4 != 5 || arg5 != 6 ||
-    arg6 != 7/
+/arg0 != 1 || arg1 != 2 || arg2 != 3 || arg3 != 4 || arg4 != 5 || arg5 != 6/
 {
 	printf("sdt arg mismatch\n\n");
-	printf("args are  : %d, %d, %d, %d, %d, %d, %d\n", arg0, arg1, arg2,
-	    arg3, arg4, arg5, arg6);
-	printf("should be : 1, 2, 3, 4, 5, 6, 7\n");
+	printf("args are  : %d, %d, %d, %d, %d, %d\n", arg0, arg1, arg2,
+	    arg3, arg4, arg5);
+	printf("should be : 1, 2, 3, 4, 5, 6\n");
 	exit(1);
 }
 

--- a/sys/amd64/include/sdt_machdep.h
+++ b/sys/amd64/include/sdt_machdep.h
@@ -1,0 +1,12 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#ifndef _SYS_SDT_MACHDEP_H_
+#define	_SYS_SDT_MACHDEP_H_
+
+#define	_SDT_ASM_PATCH_INSTR	"nop; nop; nop; nop; nop"
+
+#endif

--- a/sys/arm/arm/sdt_machdep.c
+++ b/sys/arm/arm/sdt_machdep.c
@@ -1,0 +1,63 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#include <sys/systm.h>
+#include <sys/sdt.h>
+
+#include <machine/cpu.h>
+
+/*
+ * Return true if we can overwrite a nop at "patchpoint" with a jump to the
+ * target address.
+ */
+bool
+sdt_tracepoint_valid(uintptr_t patchpoint, uintptr_t target)
+{
+	int32_t offset;
+
+	if (patchpoint == target ||
+	    (patchpoint & (INSN_SIZE - 1)) != 0 ||
+	    (target & (INSN_SIZE - 1)) != 0 ||
+	    patchpoint + 2 * INSN_SIZE < patchpoint)
+		return (false);
+	offset = target - (patchpoint + 2 * INSN_SIZE);
+	if (offset < -(1 << 24) || offset > (1 >> 24))
+		return (false);
+	return (true);
+}
+
+/*
+ * Overwrite the copy of _SDT_ASM_PATCH_INSTR at the tracepoint with a jump to
+ * the target address.
+ */
+void
+sdt_tracepoint_patch(uintptr_t patchpoint, uintptr_t target)
+{
+	uint32_t instr;
+
+	KASSERT(sdt_tracepoint_valid(patchpoint, target),
+	    ("%s: invalid tracepoint %#x -> %#x",
+	    __func__, patchpoint, target));
+
+	instr =
+	    (((target - (patchpoint + 2 * INSN_SIZE)) >> 2) & ((1 << 24) - 1)) |
+	    0xea000000;
+	memcpy((void *)patchpoint, &instr, sizeof(instr));
+	icache_sync(patchpoint, sizeof(instr));
+}
+
+/*
+ * Overwrite the patchpoint with a nop instruction.
+ */
+void
+sdt_tracepoint_restore(uintptr_t patchpoint)
+{
+	uint32_t instr;
+
+	instr = 0xe320f000u;
+	memcpy((void *)patchpoint, &instr, sizeof(instr));
+	icache_sync(patchpoint, sizeof(instr));
+}

--- a/sys/arm/include/sdt_machdep.h
+++ b/sys/arm/include/sdt_machdep.h
@@ -1,0 +1,12 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#ifndef _SYS_SDT_MACHDEP_H_
+#define	_SYS_SDT_MACHDEP_H_
+
+#define	_SDT_ASM_PATCH_INSTR	"nop"
+
+#endif /* _SYS_SDT_MACHDEP_H_ */

--- a/sys/arm64/arm64/sdt_machdep.c
+++ b/sys/arm64/arm64/sdt_machdep.c
@@ -1,0 +1,77 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#include <sys/systm.h>
+#include <sys/sdt.h>
+
+#include <vm/vm.h>
+#include <vm/pmap.h>
+
+#include <machine/cpufunc.h>
+#include <machine/md_var.h>
+#include <machine/vmparam.h>
+
+/*
+ * Return true if we can overwrite a nop at "patchpoint" with a jump to the
+ * target address.
+ */
+bool
+sdt_tracepoint_valid(uintptr_t patchpoint, uintptr_t target)
+{
+	void *addr;
+	int64_t offset;
+
+	if (!arm64_get_writable_addr((void *)patchpoint, &addr))
+		return (false);
+
+	if (patchpoint == target ||
+	    (patchpoint & (INSN_SIZE - 1)) != 0 ||
+	    (target & (INSN_SIZE - 1)) != 0)
+		return (false);
+	offset = target - patchpoint;
+	if (offset < -(1 << 26) || offset > (1 << 26))
+		return (false);
+	return (true);
+}
+
+/*
+ * Overwrite the copy of _SDT_ASM_PATCH_INSTR at the tracepoint with a jump to the
+ * target address.
+ */
+void
+sdt_tracepoint_patch(uintptr_t patchpoint, uintptr_t target)
+{
+	void *addr;
+	uint32_t instr;
+
+	KASSERT(sdt_tracepoint_valid(patchpoint, target),
+	    ("%s: invalid tracepoint %#lx -> %#lx",
+	    __func__, patchpoint, target));
+
+	if (!arm64_get_writable_addr((void *)patchpoint, &addr))
+		panic("%s: Unable to write new instruction", __func__);
+
+	instr = (((target - patchpoint) >> 2) & 0x3fffffful) | 0x14000000;
+	memcpy(addr, &instr, sizeof(instr));
+	cpu_icache_sync_range((void *)patchpoint, INSN_SIZE);
+}
+
+/*
+ * Overwrite the patchpoint with a nop instruction.
+ */
+void
+sdt_tracepoint_restore(uintptr_t patchpoint)
+{
+	void *addr;
+	uint32_t instr;
+
+	if (!arm64_get_writable_addr((void *)patchpoint, &addr))
+		panic("%s: Unable to write new instruction", __func__);
+
+	instr = 0xd503201f;
+	memcpy(addr, &instr, sizeof(instr));
+	cpu_icache_sync_range((void *)patchpoint, INSN_SIZE);
+}

--- a/sys/arm64/include/sdt_machdep.h
+++ b/sys/arm64/include/sdt_machdep.h
@@ -1,0 +1,12 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#ifndef _SYS_SDT_MACHDEP_H_
+#define	_SYS_SDT_MACHDEP_H_
+
+#define	_SDT_ASM_PATCH_INSTR	"nop"
+
+#endif /* _SYS_SDT_MACHDEP_H_ */

--- a/sys/cddl/dev/dtrace/dtrace_test.c
+++ b/sys/cddl/dev/dtrace/dtrace_test.c
@@ -37,8 +37,8 @@
 
 SDT_PROVIDER_DEFINE(test);
 
-SDT_PROBE_DEFINE7(test, , , sdttest, "int", "int", "int", "int", "int",
-    "int", "int");
+SDT_PROBE_DEFINE6(test, , , sdttest, "int", "int", "int", "int", "int",
+    "int");
 
 /*
  * These are variables that the DTrace test suite references in the
@@ -68,7 +68,7 @@ dtrace_test_sdttest(SYSCTL_HANDLER_ARGS)
 	else if (val == 0)
 		return (0);
 
-	SDT_PROBE7(test, , , sdttest, 1, 2, 3, 4, 5, 6, 7);
+	SDT_PROBE6(test, , , sdttest, 1, 2, 3, 4, 5, 6);
 
 	return (error);
 }

--- a/sys/cddl/dev/sdt/sdt.c
+++ b/sys/cddl/dev/sdt/sdt.c
@@ -19,7 +19,7 @@
  * CDDL HEADER END
  *
  * Portions Copyright 2006-2008 John Birrell jb@freebsd.org
- *
+ * Copyright 2024 Mark Johnston <markj@FreeBSD.org>
  */
 
 /*
@@ -200,10 +200,62 @@ sdt_provide_probes(void *arg, dtrace_probedesc_t *desc)
 {
 }
 
+struct sdt_enable_cb_arg {
+	struct sdt_probe *probe;
+	int cpu;
+	int arrived;
+	int done;
+	bool enable;
+};
+
+static void
+sdt_probe_update_cb(void *_arg)
+{
+	struct sdt_enable_cb_arg *arg;
+	struct sdt_tracepoint *tp;
+
+	arg = _arg;
+	if (arg->cpu != curcpu) {
+		atomic_add_rel_int(&arg->arrived, 1);
+		while (atomic_load_acq_int(&arg->done) == 0)
+			cpu_spinwait();
+		return;
+	} else {
+		while (atomic_load_acq_int(&arg->arrived) != mp_ncpus - 1)
+			cpu_spinwait();
+	}
+
+	STAILQ_FOREACH(tp, &arg->probe->tracepoint_list, tracepoint_entry) {
+		if (arg->enable)
+			sdt_tracepoint_patch(tp->patchpoint, tp->target);
+		else
+			sdt_tracepoint_restore(tp->patchpoint);
+	}
+
+	atomic_store_rel_int(&arg->done, 1);
+}
+
+static void
+sdt_probe_update(struct sdt_probe *probe, bool enable)
+{
+	struct sdt_enable_cb_arg cbarg;
+
+	sched_pin();
+	cbarg.probe = probe;
+	cbarg.cpu = curcpu;
+	atomic_store_rel_int(&cbarg.arrived, 0);
+	atomic_store_rel_int(&cbarg.done, 0);
+	cbarg.enable = enable;
+	smp_rendezvous(NULL, sdt_probe_update_cb, NULL, &cbarg);
+	sched_unpin();
+}
+
 static void
 sdt_enable(void *arg __unused, dtrace_id_t id, void *parg)
 {
-	struct sdt_probe *probe = parg;
+	struct sdt_probe *probe;
+
+	probe = parg;
 
 	probe->id = id;
 	probe->sdtp_lf->nenabled++;
@@ -215,14 +267,19 @@ sdt_enable(void *arg __unused, dtrace_id_t id, void *parg)
 	sdt_probes_enabled_count++;
 	if (sdt_probes_enabled_count == 1)
 		sdt_probes_enabled = true;
+
+	sdt_probe_update(probe, true);
 }
 
 static void
 sdt_disable(void *arg __unused, dtrace_id_t id, void *parg)
 {
-	struct sdt_probe *probe = parg;
+	struct sdt_probe *probe;
 
+	probe = parg;
 	KASSERT(probe->sdtp_lf->nenabled > 0, ("no probes enabled"));
+
+	sdt_probe_update(probe, false);
 
 	sdt_probes_enabled_count--;
 	if (sdt_probes_enabled_count == 0)
@@ -284,24 +341,45 @@ sdt_kld_load_providers(struct linker_file *lf)
 static void
 sdt_kld_load_probes(struct linker_file *lf)
 {
-	struct sdt_probe **probe, **p_begin, **p_end;
-	struct sdt_argtype **argtype, **a_begin, **a_end;
+	struct sdt_probe **p_begin, **p_end;
+	struct sdt_argtype **a_begin, **a_end;
+	struct sdt_tracepoint *tp_begin, *tp_end;
 
 	if (linker_file_lookup_set(lf, "sdt_probes_set", &p_begin, &p_end,
 	    NULL) == 0) {
-		for (probe = p_begin; probe < p_end; probe++) {
+		for (struct sdt_probe **probe = p_begin; probe < p_end;
+		    probe++) {
 			(*probe)->sdtp_lf = lf;
 			sdt_create_probe(*probe);
 			TAILQ_INIT(&(*probe)->argtype_list);
+			STAILQ_INIT(&(*probe)->tracepoint_list);
 		}
 	}
 
 	if (linker_file_lookup_set(lf, "sdt_argtypes_set", &a_begin, &a_end,
 	    NULL) == 0) {
-		for (argtype = a_begin; argtype < a_end; argtype++) {
+		for (struct sdt_argtype **argtype = a_begin; argtype < a_end;
+		    argtype++) {
 			(*argtype)->probe->n_args++;
 			TAILQ_INSERT_TAIL(&(*argtype)->probe->argtype_list,
 			    *argtype, argtype_entry);
+		}
+	}
+
+	if (linker_file_lookup_set(lf, __XSTRING(_SDT_TRACEPOINT_SET),
+	    &tp_begin, &tp_end, NULL) == 0) {
+		for (struct sdt_tracepoint *tp = tp_begin; tp < tp_end; tp++) {
+			if (!sdt_tracepoint_valid(tp->patchpoint, tp->target)) {
+				printf(
+			    "invalid tracepoint %#jx->%#jx for %s:%s:%s:%s\n",
+				    (uintmax_t)tp->patchpoint,
+				    (uintmax_t)tp->target,
+				    tp->probe->prov->name, tp->probe->mod,
+				    tp->probe->func, tp->probe->name);
+				continue;
+			}
+			STAILQ_INSERT_TAIL(&tp->probe->tracepoint_list, tp,
+			    tracepoint_entry);
 		}
 	}
 }
@@ -378,6 +456,7 @@ sdt_load(void)
 	TAILQ_INIT(&sdt_prov_list);
 
 	sdt_probe_func = dtrace_probe;
+	sdt_probe6_func = (sdt_probe6_func_t)dtrace_probe;
 
 	sdt_kld_load_tag = EVENTHANDLER_REGISTER(kld_load, sdt_kld_load, NULL,
 	    EVENTHANDLER_PRI_ANY);
@@ -403,6 +482,7 @@ sdt_unload(void)
 	EVENTHANDLER_DEREGISTER(kld_unload_try, sdt_kld_unload_try_tag);
 
 	sdt_probe_func = sdt_probe_stub;
+	sdt_probe6_func = (sdt_probe6_func_t)sdt_probe_stub;
 
 	TAILQ_FOREACH_SAFE(prov, &sdt_prov_list, prov_entry, tmp) {
 		ret = dtrace_unregister(prov->id);
@@ -419,7 +499,6 @@ sdt_unload(void)
 static int
 sdt_modevent(module_t mod __unused, int type, void *data __unused)
 {
-
 	switch (type) {
 	case MOD_LOAD:
 	case MOD_UNLOAD:

--- a/sys/conf/files.arm
+++ b/sys/conf/files.arm
@@ -58,6 +58,7 @@ arm/arm/pmu.c			optional	pmu | hwpmc
 arm/arm/pmu_fdt.c		optional	fdt pmu | fdt hwpmc
 arm/arm/ptrace_machdep.c	standard
 arm/arm/sc_machdep.c		optional	sc
+arm/arm/sdt_machdep.c		optional	kdtrace_hooks
 arm/arm/setcpsr.S		standard
 arm/arm/setstack.S		standard
 arm/arm/stack_machdep.c		optional	ddb | stack

--- a/sys/conf/files.arm64
+++ b/sys/conf/files.arm64
@@ -68,6 +68,7 @@ arm64/arm64/ptrauth.c				standard \
 	compile-with	"${NORMAL_C:N-mbranch-protection*} -mbranch-protection=bti"
 arm64/arm64/pmap.c				standard
 arm64/arm64/ptrace_machdep.c			standard
+arm64/arm64/sdt_machdep.c			optional kdtrace_hooks
 arm64/arm64/sigtramp.S				standard
 arm64/arm64/stack_machdep.c			optional ddb | stack
 arm64/arm64/strcmp.S				standard

--- a/sys/conf/files.powerpc
+++ b/sys/conf/files.powerpc
@@ -336,6 +336,7 @@ powerpc/powerpc/platform.c	standard
 powerpc/powerpc/platform_if.m	standard
 powerpc/powerpc/ptrace_machdep.c	standard
 powerpc/powerpc/sc_machdep.c	optional	sc
+powerpc/powerpc/sdt_machdep.c	optional	powerpc64 kdtrace_hooks
 powerpc/powerpc/setjmp.S	standard
 powerpc/powerpc/sigcode32.S	optional	powerpc | powerpcspe | compat_freebsd32
 powerpc/powerpc/sigcode64.S	optional	powerpc64 | powerpc64le

--- a/sys/conf/files.riscv
+++ b/sys/conf/files.riscv
@@ -61,6 +61,7 @@ riscv/riscv/riscv_syscon.c	optional	syscon riscv_syscon fdt
 riscv/riscv/sigtramp.S		standard
 riscv/riscv/sbi.c		standard
 riscv/riscv/sbi_ipi.c		optional	smp
+riscv/riscv/sdt_machdep.c	optional	kdtrace_hooks
 riscv/riscv/stack_machdep.c	optional	ddb | stack
 riscv/riscv/support.S		standard
 riscv/riscv/swtch.S		standard

--- a/sys/conf/files.x86
+++ b/sys/conf/files.x86
@@ -377,6 +377,7 @@ x86/x86/x86_mem.c		optional	mem
 x86/x86/mp_x86.c		optional	smp
 x86/x86/nexus.c			standard
 x86/x86/pvclock.c		optional	kvm_clock | xenhvm
+x86/x86/sdt_machdep.c		optional	kdtrace_hooks
 x86/x86/stack_machdep.c		optional	ddb | stack
 x86/x86/tsc.c			standard
 x86/x86/ucode.c			standard

--- a/sys/i386/include/sdt_machdep.h
+++ b/sys/i386/include/sdt_machdep.h
@@ -1,0 +1,19 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#ifndef _SYS_SDT_MACHDEP_H_
+#define	_SYS_SDT_MACHDEP_H_
+
+#define	_SDT_ASM_PATCH_INSTR		"nop; nop; nop; nop; nop"
+
+/*
+ * Work around an apparent clang bug or limitation which prevents the use of the
+ * "i" (immediate) constraint with the probe structure.
+ */
+#define	_SDT_ASM_PROBE_CONSTRAINT	"Ws"
+#define	_SDT_ASM_PROBE_OPERAND		"p"
+
+#endif

--- a/sys/kern/kern_sdt.c
+++ b/sys/kern/kern_sdt.c
@@ -37,6 +37,7 @@ SDT_PROVIDER_DEFINE(sdt);
  * dtrace_probe() when it loads.
  */
 sdt_probe_func_t sdt_probe_func = sdt_probe_stub;
+sdt_probe6_func_t sdt_probe6_func = (sdt_probe6_func_t)sdt_probe_stub;
 volatile bool __read_frequently sdt_probes_enabled;
 
 /*
@@ -45,10 +46,24 @@ volatile bool __read_frequently sdt_probes_enabled;
  * to enable it.
  */
 void
-sdt_probe_stub(uint32_t id, uintptr_t arg0, uintptr_t arg1,
-    uintptr_t arg2, uintptr_t arg3, uintptr_t arg4)
+sdt_probe_stub(uint32_t id __unused, uintptr_t arg0 __unused,
+    uintptr_t arg1 __unused, uintptr_t arg2 __unused, uintptr_t arg3 __unused,
+    uintptr_t arg4 __unused)
 {
-
 	printf("sdt_probe_stub: unexpectedly called\n");
 	kdb_backtrace();
+}
+
+void
+sdt_probe(uint32_t id, uintptr_t arg0, uintptr_t arg1,
+    uintptr_t arg2, uintptr_t arg3, uintptr_t arg4)
+{
+	sdt_probe_func(id, arg0, arg1, arg2, arg3, arg4);
+}
+
+void
+sdt_probe6(uint32_t id, uintptr_t arg0, uintptr_t arg1,
+    uintptr_t arg2, uintptr_t arg3, uintptr_t arg4, uintptr_t arg5)
+{
+	sdt_probe6_func(id, arg0, arg1, arg2, arg3, arg4, arg5);
 }

--- a/sys/modules/dtrace/Makefile
+++ b/sys/modules/dtrace/Makefile
@@ -10,7 +10,6 @@ SUBDIR=		dtaudit		\
 		fbt		\
 		profile		\
 		prototype	\
-		sdt		\
 		systrace
 
 .if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386"
@@ -30,6 +29,9 @@ SUBDIR+=	fasttrap
     ${MACHINE_CPUARCH} == "aarch64" || \
     ${MACHINE_ARCH} == "powerpc64"
 SUBDIR+=	systrace_freebsd32
+.endif
+.if ${MACHINE_CPUARCH} != "powerpc" || ${MACHINE_ARCH} == "powerpc64"
+SUBDIR+=	sdt
 .endif
 
 .include <bsd.subdir.mk>

--- a/sys/powerpc/include/sdt_machdep.h
+++ b/sys/powerpc/include/sdt_machdep.h
@@ -1,0 +1,12 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#ifndef _SYS_SDT_MACHDEP_H_
+#define	_SYS_SDT_MACHDEP_H_
+
+#define	_SDT_ASM_PATCH_INSTR	"nop"
+
+#endif

--- a/sys/powerpc/powerpc/sdt_machdep.c
+++ b/sys/powerpc/powerpc/sdt_machdep.c
@@ -1,0 +1,59 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#include <sys/systm.h>
+#include <sys/sdt.h>
+
+#include <machine/md_var.h>
+
+/*
+ * Return true if we can overwrite a nop at "patchpoint" with a jump to the
+ * target address.
+ */
+bool
+sdt_tracepoint_valid(uintptr_t patchpoint, uintptr_t target)
+{
+	int64_t offset;
+
+	if (patchpoint == target ||
+	    (patchpoint & 3) != 0 || (target & 3) != 0)
+		return (false);
+	offset = target - patchpoint;
+	if (offset < -(1 << 26) || offset > (1 << 26))
+		return (false);
+	return (true);
+}
+
+/*
+ * Overwrite the copy of _SDT_ASM_PATCH_INSTR at the tracepoint with a jump to
+ * the target address.
+ */
+void
+sdt_tracepoint_patch(uintptr_t patchpoint, uintptr_t target)
+{
+	uint32_t instr;
+
+	KASSERT(sdt_tracepoint_valid(patchpoint, target),
+	    ("%s: invalid tracepoint %#lx -> %#lx",
+	    __func__, patchpoint, target));
+
+	instr = ((target - patchpoint) & 0x7fffffful) | 0x48000000;
+	memcpy((void *)patchpoint, &instr, sizeof(instr));
+	__syncicache((void *)patchpoint, sizeof(instr));
+}
+
+/*
+ * Overwrite the patchpoint with a nop instruction.
+ */
+void
+sdt_tracepoint_restore(uintptr_t patchpoint)
+{
+	uint32_t instr;
+
+	instr = 0x60000000;
+	memcpy((void *)patchpoint, &instr, sizeof(instr));
+	__syncicache((void *)patchpoint, sizeof(instr));
+}

--- a/sys/riscv/include/sdt_machdep.h
+++ b/sys/riscv/include/sdt_machdep.h
@@ -1,0 +1,12 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#ifndef _SYS_SDT_MACHDEP_H_
+#define	_SYS_SDT_MACHDEP_H_
+
+#define	_SDT_ASM_PATCH_INSTR	".option push; .option norvc; nop; .option pop"
+
+#endif /* _SYS_SDT_MACHDEP_H_ */

--- a/sys/riscv/riscv/sdt_machdep.c
+++ b/sys/riscv/riscv/sdt_machdep.c
@@ -1,0 +1,68 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#include <sys/systm.h>
+#include <sys/sdt.h>
+
+#include <machine/encoding.h>
+
+/*
+ * Return true if we can overwrite a nop at "patchpoint" with a jump to the
+ * target address.
+ */
+bool
+sdt_tracepoint_valid(uintptr_t patchpoint, uintptr_t target)
+{
+	int64_t offset;
+
+	if (patchpoint == target ||
+	    (patchpoint & (INSN_C_SIZE - 1)) != 0 ||
+	    (target & (INSN_C_SIZE - 1)) != 0)
+		return (false);
+	offset = target - patchpoint;
+	if (offset < -(1 << 19) || offset > (1 << 19))
+		return (false);
+	return (true);
+}
+
+/*
+ * Overwrite the copy of _SDT_ASM_PATCH_INSTR at the tracepoint with a jump to
+ * the target address.
+ */
+void
+sdt_tracepoint_patch(uintptr_t patchpoint, uintptr_t target)
+{
+	int32_t imm;
+	uint32_t instr;
+
+	KASSERT(sdt_tracepoint_valid(patchpoint, target),
+	    ("%s: invalid tracepoint %#lx -> %#lx",
+	    __func__, patchpoint, target));
+
+	imm = target - patchpoint;
+	imm = (imm & 0x100000) |
+	    ((imm & 0x7fe) << 8) |
+	    ((imm & 0x800) >> 2) |
+	    ((imm & 0xff000) >> 12);
+	instr = (imm << 12) | MATCH_JAL;
+
+	memcpy((void *)patchpoint, &instr, sizeof(instr));
+	fence_i();
+}
+
+/*
+ * Overwrite the patchpoint with a nop instruction.
+ */
+void
+sdt_tracepoint_restore(uintptr_t patchpoint)
+{
+	uint32_t instr;
+
+	instr = 0x13; /* uncompressed nop */
+
+	memcpy((void *)patchpoint, &instr, sizeof(instr));
+	fence_i();
+}

--- a/sys/x86/x86/sdt_machdep.c
+++ b/sys/x86/x86/sdt_machdep.c
@@ -1,0 +1,84 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Mark Johnston <markj@FreeBSD.org>
+ */
+
+#include <sys/systm.h>
+#include <sys/sdt.h>
+
+#include <vm/vm.h>
+#include <vm/pmap.h>
+
+#include <machine/md_var.h>
+#include <machine/vmparam.h>
+
+#define	SDT_PATCH_SIZE		5
+
+/*
+ * Return true if we can overwrite a nop at "patchpoint" with a jump to the
+ * target address.
+ */
+bool
+sdt_tracepoint_valid(uintptr_t patchpoint, uintptr_t target)
+{
+#ifdef __amd64__
+	if (patchpoint < KERNSTART || target < KERNSTART)
+		return (false);
+#endif
+	if (patchpoint == target ||
+	    patchpoint + SDT_PATCH_SIZE < patchpoint)
+		return (false);
+#ifdef __amd64__
+	int64_t offset = target - (patchpoint + SDT_PATCH_SIZE);
+	if (offset < -(1l << 31) || offset > (1l << 31))
+		return (false);
+#endif
+	return (true);
+}
+
+/*
+ * Overwrite the copy of _SDT_ASM_PATCH_INSTR at the tracepoint with a jump to
+ * the target address.
+ */
+void
+sdt_tracepoint_patch(uintptr_t patchpoint, uintptr_t target)
+{
+	uint8_t instr[SDT_PATCH_SIZE];
+	int32_t disp;
+	bool old_wp;
+
+	KASSERT(sdt_tracepoint_valid(patchpoint, target),
+	    ("%s: invalid tracepoint %#jx -> %#jx",
+	    __func__, (uintmax_t)patchpoint, (uintmax_t)target));
+
+	instr[0] = 0xe9;
+	disp = target - (patchpoint + SDT_PATCH_SIZE);
+	memcpy(&instr[1], &disp, sizeof(disp));
+
+	old_wp = disable_wp();
+	memcpy((void *)patchpoint, instr, sizeof(instr));
+	restore_wp(old_wp);
+}
+
+/*
+ * Overwrite the patchpoint with a nop instruction.
+ */
+void
+sdt_tracepoint_restore(uintptr_t patchpoint)
+{
+	uint8_t instr[SDT_PATCH_SIZE];
+	bool old_wp;
+
+#ifdef __amd64__
+	KASSERT(patchpoint >= KERNSTART,
+	    ("%s: invalid patchpoint %#lx", __func__, patchpoint));
+#endif
+
+	for (int i = 0; i < SDT_PATCH_SIZE; i++)
+		instr[i] = 0x90;
+
+	old_wp = disable_wp();
+	memcpy((void *)patchpoint, instr, sizeof(instr));
+	restore_wp(old_wp);
+}


### PR DESCRIPTION
The idea here is to avoid a memory access and conditional branch per probe site.  Instead, the probe is represented by an "unreachable" unconditional function call.  asm goto is used to store the address of the probe site (represented by a no-op sled) and the address of the function call into a tracepoint record.  Each SDT probe carries a list of tracepoints.

When the probe is enabled, the no-op sled corresponding to each tracepoint is overwritten with a jmp to the corresponding label.  The implementation uses smp_rendezvous() to park all other CPUs while the instruction is being overwritten, as this can't be done atomically in general.

I verified that llvm 17 moves argument marshalling code and the sdt_probe() function call out-of-line, i.e., to the end of the function.

Per gallatin@ in D43504, this approach has less overhead when probes are disabled.  To make the implementation simpler, I removed support for probes with 7 arguments; nothing makes use of this except a regression test case.  I also didn't implement this for 32-bit powerpc since I wasn't able to figure out how to boot it in QEMU.

I have a couple of follow-up patches which take this further:

1. We can now fill out the "function" field of SDT probe names automatically, since we know exactly where each tracepoint is located.

2. We can put additional code between the asm goto target label and the probe itself.  This lets us perform some probe-specific argument marshalling without any overhead when the probe is disabled.  For example:

```
if (SDT_PROBES_ENABLED()) {
	int reason = CLD_EXITED;

	if (WCOREDUMP(signo))
		reason = CLD_DUMPED;
	else if (WIFSIGNALED(signo))
		reason = CLD_KILLED;
	SDT_PROBE1(proc, , , exit, reason);
}
```

becomes

```
SDT_PROBE1_EXP(proc, , , exit, reason,
	int reason;

	reason = CLD_EXITED;
	if (WCOREDUMP(signo))
		reason = CLD_DUMPED;
	else if (WIFSIGNALED(signo))
		reason = CLD_KILLED;
);
```

In the future I would like to use this mechanism more generally, e.g., to remove branches and marshalling code used by hwpmc, and generally to make it easier to add new tracepoint consumers without having to add more conditional branches to hot code paths.